### PR TITLE
updates to datatable function and styling

### DIFF
--- a/responsive-datatables/app.R
+++ b/responsive-datatables/app.R
@@ -2,9 +2,9 @@
 #' FILE: app.R
 #' AUTHOR: David Ruvolo
 #' CREATED: 2019-12-05
-#' MODIFIED: 2019-12-05
+#' MODIFIED: 2020-01-08
 #' PURPOSE: create responsive datatables in shiny
-#' STATUS: in.progress
+#' STATUS: working
 #' PACKAGES: shiny
 #' COMMENTS: NA
 #'//////////////////////////////////////////////////////////////////////////////

--- a/responsive-datatables/scripts/datatable.R
+++ b/responsive-datatables/scripts/datatable.R
@@ -2,87 +2,95 @@
 #' FILE: datatable.R
 #' AUTHOR: David Ruvolo
 #' CREATED: 2019-12-05
-#' MODIFIED: 2019-12-06
+#' MODIFIED: 2020-01-09
 #' PURPOSE: build datatable function and helpers
-#' STATUS: in.progress
+#' STATUS: working
 #' PACKAGES: shiny
 #' COMMENTS:
-#'     The datatable function uses helper functions build_header and build_body
-#'     These functions have a single input argument `data` which is received 
-#'     through the main function `datatable`. 
+#'      The datatable function generates an html table from a dataset. 
+#'      This function returns a shiny tagList object which can be used in shiny 
+#'      applications, markdown documents, or written to an html file. The 
+#'      datatable function takes the following arguments.
+#' 
+#'      ARGUMENTS:
+#'      - data: the input dataset
+#'      - id: an unique identifier for the table ideal for styling specific tables
+#'            or for selecting tables in js (e.g., "summary_table", "resultsTable")
+#'      - caption: a title for the table (recommended for accessible tables)
+#'      - options: a list of configurations that control the rendering of the table
+#'          - responsive: a logical argument for turning on/off the rendering of 
+#'                        additional elements for responsive tables (i.e., span).
+#'                        (Default = FALSE)
+#' 
+#'      ABOUT:
+#'      The datatable function requires two helper functions: 1) to generate the
+#'      table header and another used 2) to generate the table body. The function
+#'      build_header() renders the <thead> element according to the input dataset.
+#'      The build_body functions renders the table's <tbody> based on the input
+#'      and the options. This function uses a nested lapplys to iterate each row
+#'      and cell. If the responsive option is TRUE, then the function will return
+#'      a <span> element with the current cell's column name. The span element has
+#'      the class `hidden-colname` which hides or shows the element based on screen
+#'      size (see datatable.css). Role attributes are added by default in the event
+#'      the display properties are altered.
 #'//////////////////////////////////////////////////////////////////////////////
 
 # pkgs
 suppressPackageStartupMessages(library(shiny))
 
+#'////////////////////////////////////////
+
 # ~ 1 ~
 # DEFINE HELPER FUNCTIONS
-# define a series of helper functions that render specific elements of the
-# table
-
-# modularize helper functions
-helpers <- list()
+datatable_helpers <- list()
 
 # ~ a ~
 # FUNCTION: build_header
-# define a function that renders input data to <thead> html element
-# the scope attribute is used for accessibility; additional attributes
-# may be necessary for complex datatables, but it wouldn't apply in 
-# this case as this function does not support complex layouts (yet)
-helpers$build_header <- function(data){
+datatable_helpers$build_header <- function(data){
     columns <- colnames(data)
     cells <- lapply(1:length(columns), function(n){
         cell <- tags$th(columns[n])
-        cell$attribs$scope <- "col"
         cell
     })
     tags$thead(tags$tr(cells))
 }
 
-
 # ~ b ~
 # FUNCTION: build_body
-# define a function that renders input data to <tbody> html element
-# attach colnames to each cell for use in css using `data-*` attributes
-# update the row name with row n, column 1. This may be useful for
-# alternative layouts
-helpers$build_body <- function(data){
+datatable_helpers$build_body <- function(data, options){
     body <- lapply(1:NROW(data), function(row){
         cells <- lapply(1:NCOL(data), function(col){
-            if(col == 1){
-                cell <- tags$th(data[row,col])
-                cell$attribs$scope <- "row"
+            if(isTRUE(options$responsive)){
+                if(col == 1 & isTRUE(options$rowHeaders)){
+                    cell <- tags$th(role="cell")
+                } else {
+                    cell <- tags$td(role="cell")
+                }
+                cell$children <- list(
+                    tags$span(class="hidden-colname", colnames(data)[col]),
+                    data[row,col]
+                )
+                cell
             } else {
-                cell <- tags$td(data[row,col])
+                cell <- tags$td(role="cell", data[row,col])
             }
-            cell$attribs$`data-colname` <- colnames(data)[col]
             cell
         })
-        tags$tr(cells)
+        tags$tr(role="row", cells)
     })
     tags$tbody(body)
 }
-
-# If you want to add a more attributes to the row element `tr`, use:
-#
-#   tags$tr(cells, `data-rowname`=data[row, 1])
-#
 
 #'////////////////////////////////////////
 
 # ~ 2 ~
 # FUNCTION: datatable
-# define a function that builds all elements of the datatable. This
-# includes data (the object containing the data you want to use to
-# create a table) and caption (a title for the table). Caption is set
-# to NULL by default, but a caption should be used for good accessibility
-# practices.
-datatable <- function(data, id = NULL, caption = NULL){
+datatable <- function(data, id = NULL, caption = NULL, options = list(responsive = TRUE, rowHeaders = TRUE)){
     
     # render table and table elements
     tbl <- tags$table(class="datatable")
-    thead <- helpers$build_header(data)
-    tbody <- helpers$build_body(data)
+    thead <- datatable_helpers$build_header(data)
+    tbody <- datatable_helpers$build_body(data, options)
     
     # add id
     if(!is.null(id)){
@@ -91,10 +99,8 @@ datatable <- function(data, id = NULL, caption = NULL){
     
     # should a caption be rendered?
     if(!is.null(caption)){
-        captionId <- paste0("datatable-",id,"-caption")
-        tbl$attribs$`aria-labelledby` <- captionId
         tbl$children <- list(
-            tags$caption(caption, id= captionId),
+            tags$caption(caption),
             thead,
             tbody
         )

--- a/responsive-datatables/www/css/datatable.css
+++ b/responsive-datatables/www/css/datatable.css
@@ -1,0 +1,62 @@
+.datatable {
+	width: 100%;
+	border-spacing: 0;
+	text-align: left;
+    font-size: 13pt;
+}
+
+.datatable caption {
+	text-align: left;
+	font-size: 16pt;
+	margin: 12px 0;
+	color: #252525;
+	font-weight: 600;
+}
+
+.datatable thead tr th {
+	font-weight: 600;
+    padding: 4px 12px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+	border-bottom: 1px solid #252525;
+    color: #252525;
+}
+
+.datatable tbody tr th,
+.datatable tbody tr td {
+    font-weight: 400;
+	padding: 24px 12px;
+}
+
+.datatable tbody tr:nth-child(even) {
+	background-color: #f6f6f6;
+}
+
+.datatable .hidden-colname {
+    display: inline-block;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+@media (max-width: 892px){
+    .datatable thead {
+		display: none;
+    }
+	
+	.datatable tbody tr th,
+	.datatable tbody tr td {
+        display: block;
+        padding:  5px 0 5px 12px;
+    }
+    
+    .datatable .hidden-colname {
+        display: inline-block;
+        clip: auto;
+        width: 150px;
+        height: 100%;
+        line-height: 1;
+    }
+}

--- a/responsive-datatables/www/css/styles.css
+++ b/responsive-datatables/www/css/styles.css
@@ -78,7 +78,9 @@ p {
 
 .datatable thead tr th {
 	font-weight: 600;
-	padding: 4px 12px;
+    padding: 4px 12px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
 	border-bottom: 1px solid var(--dark);
     color: var(--dark);
 }
@@ -93,6 +95,15 @@ p {
 	background-color: var(--light);
 }
 
+.datatable .hidden-colname {
+    display: inline-block;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px);
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
 @media (max-width: 892px){
     .datatable thead {
 		display: none;
@@ -104,13 +115,12 @@ p {
         padding:  5px 0 5px 12px;
     }
     
-    .datatable tbody tr th {
-        font-weight: 600;
-    }
-    
-	.datatable tbody tr td::before {
-        content: attr(data-colname) ": ";
+
+    .datatable .hidden-colname {
         display: inline-block;
+        clip: auto;
         width: 150px;
+        height: 100%;
+        line-height: 1;
     }
 }


### PR DESCRIPTION
This request includes the following changes to the datatable application and function (addresses issue #7).

- Updated datatable function with `options` argument: the function now has a list of options that can be used to configure the rendering of the table. 
    - The option `responsive` (default = TRUE) allows you to disable or enable the rendering of a `<span>` element in each cell. The span element is used to show or hide column headers based on screen size. 
    - The option `rowHeader` (default = TRUE) renders the first cell in each row as a header. This is to be used if all cells in the row are related. 
- Updated datatable helpers: bother helper functions were updated to accommodate the options. 
- CSS: the corresponding css was updated to handle the displaying of the hidden column name. Styles were also copied into an independent file (see `datatable.css`).