### PR TITLE
adjustments to table elements & added a link to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Many of the tutorials use css and javascript, as well as html to specific layout
 
 - [a11y project](https://a11yproject.com)
 - [Mozilla's Learn Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+- [macOS Voice Over Commands](https://help.apple.com/voiceover/command-charts/)
 - [WAI's Web Accessibility Tutorials](https://www.w3.org/WAI/tutorials/)
 - [Web Accessibility Initiative](https://www.w3.org/WAI/)
 

--- a/responsive-datatables/app.R
+++ b/responsive-datatables/app.R
@@ -2,11 +2,13 @@
 #' FILE: app.R
 #' AUTHOR: David Ruvolo
 #' CREATED: 2019-12-05
-#' MODIFIED: 2020-01-08
+#' MODIFIED: 2020-01-10
 #' PURPOSE: create responsive datatables in shiny
 #' STATUS: working
 #' PACKAGES: shiny
-#' COMMENTS: NA
+#' COMMENTS:
+#'      The datatable function can be found here: scripts/datatable.R. The
+#'      re-orgranizing of content is handled by css (see www/css/*.css for info).
 #'//////////////////////////////////////////////////////////////////////////////
 
 # pkgs
@@ -34,7 +36,7 @@ ui <- tagList(
         tags$main(class="main", 
             tags$section(class="section",
                 tags$h2("Responsive datatables in shiny"),
-                tags$p("This application demonstrates how to create response datatables in shiny. The custom function datatable() renders the required table elements and adds data to html elements using `data` attributes. The data attributes can then be used as restructure tables using css pseudo elements. In this example, I'm using data from birdData Australia. The data is the top 25 most commonly reported birds in 2018 Birds in Backyards program. Resize the browser to see this in action!"),
+                tags$p("This application demonstrates how to create responsive and accessible datatables in shiny. The custom function datatable() renders the required table elements from your dataset and adds visually hidden and displayed elements when the screen is resized or if accessed on mobile. In this example, a datatable is generated using data from birdData Australia. The data is the top 25 most commonly reported birds in 2018 Birds in Backyards program. Resize the browser to see how the table visually changes and examine the code to see how the table is rendered."),
                 uiOutput("table")
             )
         )

--- a/responsive-datatables/scripts/datatable.R
+++ b/responsive-datatables/scripts/datatable.R
@@ -2,7 +2,7 @@
 #' FILE: datatable.R
 #' AUTHOR: David Ruvolo
 #' CREATED: 2019-12-05
-#' MODIFIED: 2020-01-09
+#' MODIFIED: 2020-01-10
 #' PURPOSE: build datatable function and helpers
 #' STATUS: working
 #' PACKAGES: shiny
@@ -49,7 +49,7 @@ datatable_helpers <- list()
 datatable_helpers$build_header <- function(data){
     columns <- colnames(data)
     cells <- lapply(1:length(columns), function(n){
-        cell <- tags$th(columns[n])
+        cell <- tags$th(scope="col",columns[n])
         cell
     })
     tags$thead(tags$tr(cells))
@@ -62,12 +62,12 @@ datatable_helpers$build_body <- function(data, options){
         cells <- lapply(1:NCOL(data), function(col){
             if(isTRUE(options$responsive)){
                 if(col == 1 & isTRUE(options$rowHeaders)){
-                    cell <- tags$th(role="cell")
+                    cell <- tags$th(role="rowheader", scope="row")
                 } else {
                     cell <- tags$td(role="cell")
                 }
                 cell$children <- list(
-                    tags$span(class="hidden-colname", colnames(data)[col]),
+                    tags$span(class="hidden-colname", `aria-hidden`="true", colnames(data)[col]),
                     data[row,col]
                 )
                 cell

--- a/responsive-datatables/www/css/datatable.css
+++ b/responsive-datatables/www/css/datatable.css
@@ -1,35 +1,34 @@
 .datatable {
-	width: 100%;
-	border-spacing: 0;
-	text-align: left;
+    width: 100%;
+    border-spacing: 0;
+    text-align: left;
     font-size: 13pt;
 }
 
 .datatable caption {
-	text-align: left;
-	font-size: 16pt;
-	margin: 12px 0;
-	color: #252525;
-	font-weight: 600;
+    text-align: left;
+    font-size: 16pt;
+    margin: 12px 0;
+    color: var(--dark);
+    font-weight: 600;
 }
 
 .datatable thead tr th {
-	font-weight: 600;
+    font-weight: 600;
     padding: 4px 12px;
     text-transform: uppercase;
     letter-spacing: 2px;
-	border-bottom: 1px solid #252525;
-    color: #252525;
+    border-bottom: 1px solid var(--dark);
+    color: var(--dark);
 }
 
-.datatable tbody tr th,
-.datatable tbody tr td {
+.datatable tbody tr th, .datatable tbody tr td {
     font-weight: 400;
-	padding: 24px 12px;
+    padding: 24px 12px;
 }
 
 .datatable tbody tr:nth-child(even) {
-	background-color: #f6f6f6;
+    background-color: var(--light);
 }
 
 .datatable .hidden-colname {
@@ -41,22 +40,24 @@
     overflow: hidden;
 }
 
-@media (max-width: 892px){
+@media (max-width: 892px) {
     .datatable thead {
-		display: none;
+        position: absolute;
+        clip: rect(1px 1px 1px 1px);
+        clip: rect(1px, 1px, 1px, 1px);
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
     }
-	
-	.datatable tbody tr th,
-	.datatable tbody tr td {
+    .datatable tbody tr th, .datatable tbody tr td {
         display: block;
-        padding:  5px 0 5px 12px;
+        padding: 5px 0 5px 12px;
     }
-    
     .datatable .hidden-colname {
         display: inline-block;
         clip: auto;
         width: 150px;
-        height: 100%;
+        height: auto;
         line-height: 1;
     }
 }

--- a/responsive-datatables/www/css/styles.css
+++ b/responsive-datatables/www/css/styles.css
@@ -47,13 +47,13 @@ p {
     margin: 0;
 }
 
-.section{
+.section {
     width: 90%;
     padding: 3em 0;
     margin: 0 auto;
 }
 
-@media (min-width: 912px){
+@media (min-width: 912px) {
     .section {
         max-width: 912px;
         margin: 0 auto;
@@ -61,38 +61,38 @@ p {
 }
 
 /* datatable styles */
+
 .datatable {
-	width: 100%;
-	border-spacing: 0;
-	text-align: left;
+    width: 100%;
+    border-spacing: 0;
+    text-align: left;
     font-size: 13pt;
 }
 
 .datatable caption {
-	text-align: left;
-	font-size: 16pt;
-	margin: 12px 0;
-	color: var(--dark);
-	font-weight: 600;
+    text-align: left;
+    font-size: 16pt;
+    margin: 12px 0;
+    color: var(--dark);
+    font-weight: 600;
 }
 
 .datatable thead tr th {
-	font-weight: 600;
+    font-weight: 600;
     padding: 4px 12px;
     text-transform: uppercase;
     letter-spacing: 2px;
-	border-bottom: 1px solid var(--dark);
+    border-bottom: 1px solid var(--dark);
     color: var(--dark);
 }
 
-.datatable tbody tr th,
-.datatable tbody tr td {
+.datatable tbody tr th, .datatable tbody tr td {
     font-weight: 400;
-	padding: 24px 12px;
+    padding: 24px 12px;
 }
 
 .datatable tbody tr:nth-child(even) {
-	background-color: var(--light);
+    background-color: var(--light);
 }
 
 .datatable .hidden-colname {
@@ -104,23 +104,24 @@ p {
     overflow: hidden;
 }
 
-@media (max-width: 892px){
+@media (max-width: 892px) {
     .datatable thead {
-		display: none;
+        position: absolute;
+        clip: rect(1px 1px 1px 1px);
+        clip: rect(1px, 1px, 1px, 1px);
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
     }
-	
-	.datatable tbody tr th,
-	.datatable tbody tr td {
+    .datatable tbody tr th, .datatable tbody tr td {
         display: block;
-        padding:  5px 0 5px 12px;
+        padding: 5px 0 5px 12px;
     }
-    
-
     .datatable .hidden-colname {
         display: inline-block;
         clip: auto;
         width: 150px;
-        height: 100%;
+        height: auto;
         line-height: 1;
     }
 }


### PR DESCRIPTION
After testing the datatable function once more, I decided to modify the attributes a bit. This request includes the following changes.

- Elements where the display properties are changed should have `role` attributes defined
- Re-add `scope` attributes for column headers
- Minor adjustments to css styles 

For the record, for some reason, the screen reader (VoiceOver) will announce "... 0 columns and *n* rows" despite having three columns. When navigating each row, the screen reader will state, "... column *n* of *3*" when a new cell is selected. Interestingly, after navigating the table and jumping to the table, the screen reader will state the correct number of columns. Testing with another screen reader is needed.