### PR TITLE
rewrite to options handling + render text as html option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Suggestions, comments, ideas for improvement are always welcome!
 | shiny landing page | create cool landing pages in shiny | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/landing-page/)
 | time input | creating a time input widget | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/time-input/)
 
-Do you have an idea for a tutorial? Have you written a tutorial? Suggestions are always welcome! Check the contributing guidelines for more information.
-
 ## Resources
 
 Many of the tutorials use css and javascript, as well as html to specific layouts and custom designs rather than shinyUI functions. These are good skills to have and will come in handy in future shiny development. Here are some links that you may find useful.

--- a/responsive-datatables/scripts/datatable.R
+++ b/responsive-datatables/scripts/datatable.R
@@ -2,43 +2,43 @@
 #' FILE: datatable.R
 #' AUTHOR: David Ruvolo
 #' CREATED: 2019-12-05
-#' MODIFIED: 2020-01-10
+#' MODIFIED: 2020-01-13
 #' PURPOSE: build datatable function and helpers
 #' STATUS: working
-#' PACKAGES: shiny
+#' PACKAGES: htmltools
 #' COMMENTS:
-#'      The datatable function generates an html table from a dataset. 
-#'      This function returns a shiny tagList object which can be used in shiny 
-#'      applications, markdown documents, or written to an html file. The 
+#'      The datatable function generates an html table from a dataset.
+#'      This func returns a shiny tagList object which can be used in shiny
+#'      applications, markdown documents, or written to an html file. The
 #'      datatable function takes the following arguments.
-#' 
+#'
 #'      ARGUMENTS:
 #'      - data: the input dataset
-#'      - id: an unique identifier for the table ideal for styling specific tables
-#'            or for selecting tables in js (e.g., "summary_table", "resultsTable")
+#'      - id: an identifier for the table ideal for styling specific tables
+#'            or for use in js
 #'      - caption: a title for the table (recommended for accessible tables)
-#'      - options: a list of configurations that control the rendering of the table
-#'          - responsive: a logical argument for turning on/off the rendering of 
-#'                        additional elements for responsive tables (i.e., span).
-#'                        (Default = FALSE)
-#' 
+#'      - options:
+#'          - responsive: a logical arg for turning on/off the rendering of
+#'                      additional elements for responsive tables (i.e., span).
+#'                      (Default = FALSE)
+#'          - rowHeaders: a bool that renders the first cell of every row
+#'              as a row header. This is useful for datasets where all data
+#'              in a row is related, e.g., patient data. If set to TRUE,
+#'              the data must be organized so that the row header is the
+#'              first column.
+#'
 #'      ABOUT:
 #'      The datatable function requires two helper functions: 1) to generate the
-#'      table header and another used 2) to generate the table body. The function
-#'      build_header() renders the <thead> element according to the input dataset.
+#'      table header and another used 2) to generate the table body. The func
+#'      build_header() renders the <thead> element according to the input data.
 #'      The build_body functions renders the table's <tbody> based on the input
 #'      and the options. This function uses a nested lapplys to iterate each row
-#'      and cell. If the responsive option is TRUE, then the function will return
-#'      a <span> element with the current cell's column name. The span element has
-#'      the class `hidden-colname` which hides or shows the element based on screen
-#'      size (see datatable.css). Role attributes are added by default in the event
-#'      the display properties are altered.
+#'      and cell. If the responsive opt is TRUE, then the function will return
+#'      a <span> element with the current cell's column name. <span> has
+#'      the class `hidden-colname` that hides/shows the element based on screen
+#'      size (see datatable.css). Role attributes are added in the event
+#'      the display properties are altered in css.
 #'//////////////////////////////////////////////////////////////////////////////
-
-# pkgs
-suppressPackageStartupMessages(library(shiny))
-
-#'////////////////////////////////////////
 
 # ~ 1 ~
 # DEFINE HELPER FUNCTIONS
@@ -46,68 +46,101 @@ datatable_helpers <- list()
 
 # ~ a ~
 # FUNCTION: build_header
-datatable_helpers$build_header <- function(data){
+datatable_helpers$build_header <- function(data, options) {
     columns <- colnames(data)
-    cells <- lapply(1:length(columns), function(n){
-        cell <- tags$th(scope="col",columns[n])
+    cells <- lapply(1:length(columns), function(n) {
+
+        # define cell content: as html or text
+        if (isTRUE(options$asHTML)) {
+            cell_value <- htmltools::HTML(columns[n])
+        } else {
+            cell_value <- columns[n]
+        }
+
+        # build header
+        cell <- htmltools::tags$th(scope = "col", cell_value)
         cell
     })
-    tags$thead(tags$tr(cells))
+
+    # return header
+    htmltools::tags$thead(
+        htmltools::tags$tr(role = "row", cells)
+    )
 }
 
 # ~ b ~
 # FUNCTION: build_body
-datatable_helpers$build_body <- function(data, options){
-    body <- lapply(1:NROW(data), function(row){
-        cells <- lapply(1:NCOL(data), function(col){
-            if(isTRUE(options$responsive)){
-                if(col == 1 & isTRUE(options$rowHeaders)){
-                    cell <- tags$th(role="rowheader", scope="row")
-                } else {
-                    cell <- tags$td(role="cell")
-                }
-                cell$children <- list(
-                    tags$span(class="hidden-colname", `aria-hidden`="true", colnames(data)[col]),
-                    data[row,col]
-                )
-                cell
+datatable_helpers$build_body <- function(data, options) {
+    body <- lapply(1:NROW(data), function(row) {
+        cells <- lapply(1:NCOL(data), function(col) {
+
+            # process options: render as html or escape?
+            if (isTRUE(options$asHTML)) {
+                cell_value <- htmltools::HTML(data[row, col])
             } else {
-                cell <- tags$td(role="cell", data[row,col])
+                cell_value <- data[row, col]
             }
+
+            # process options$rowHeaders (this generates the cell)
+            if (isTRUE(options$rowHeaders) && col == 1) {
+                cell <- htmltools::tags$th(role = "rowheader")
+            } else {
+                cell <- htmltools::tags$td(role = "cell")
+            }
+
+            # process options: responsive and rowHeaders
+            if (isTRUE(options$responsive)) {
+                cell$children <- list(
+                    htmltools::tags$span(
+                        class = "hidden-colname",
+                        `aria-hidden` = "true",
+                        colnames(data)[col]
+                    ),
+                    cell_value
+                )
+            } else {
+                cell$children <- list(
+                    cell_value
+                )
+            }
+
+            # return cell
             cell
         })
-        tags$tr(role="row", cells)
+
+        # return cells in a row
+        htmltools::tags$tr(role = "row", cells)
     })
-    tags$tbody(body)
+
+    # return body
+    htmltools::tags$tbody(body)
 }
 
 #'////////////////////////////////////////
 
 # ~ 2 ~
 # FUNCTION: datatable
-datatable <- function(data, id = NULL, caption = NULL, options = list(responsive = TRUE, rowHeaders = TRUE)){
-    
+datatable <- function(data, id = NULL, caption = NULL, options = list(responsive = TRUE, rowHeaders = TRUE, asHTML = FALSE)) {
+
     # render table and table elements
-    tbl <- tags$table(class="datatable")
-    thead <- datatable_helpers$build_header(data)
-    tbody <- datatable_helpers$build_body(data, options)
-    
+    tbl <- htmltools::tags$table(class = "datatable",
+        datatable_helpers$build_header(data, options),
+        datatable_helpers$build_body(data, options)
+    )
+
     # add id
-    if(!is.null(id)){
+    if (!is.null(id)) {
         tbl$attribs$id <- paste0("datatable-", id)
     }
-    
+
     # should a caption be rendered?
-    if(!is.null(caption)){
+    if (!is.null(caption)) {
         tbl$children <- list(
-            tags$caption(caption),
-            thead,
-            tbody
+            htmltools::tags$caption(caption),
+            tbl$children
         )
-    } else {
-        tbl$children <- list(thead, tbody)
     }
-    
+
     # return
     tbl
 }

--- a/responsive-datatables/scripts/datatable_tests.R
+++ b/responsive-datatables/scripts/datatable_tests.R
@@ -1,0 +1,73 @@
+#'//////////////////////////////////////////////////////////////////////////////
+#' FILE: datatable_tests.R
+#' AUTHOR: David Ruvolo
+#' CREATED: 2020-01-13
+#' MODIFIED: 2020-01-13
+#' PURPOSE: run tests for datatable.R
+#' STATUS: working
+#' PACKAGES: htmltools
+#' COMMENTS: load datatable.R first
+#'//////////////////////////////////////////////////////////////////////////////
+
+# load file
+source("datatable.R")
+
+# create test data from iris 1st row
+df <- iris[1, ]
+
+# run function with default settings & no id/caption
+datatable(data = df)  # data only
+
+# with id
+datatable(data = df, id = "iris-table")
+
+# with caption
+datatable(data = df, caption = "Iris Dataset")
+
+# with responsive + rowHeaders as FALSE
+datatable(
+    data = df,
+    caption = "Iris Dataset",
+    options = list(
+        responsive = FALSE,
+        rowHeaders = FALSE
+    )
+)
+
+# with responsive as TRUE rowHeaders as FALSE
+datatable(
+    data = df,
+    caption = "Iris Dataset",
+    options = list(
+        responsive = T,
+        rowHeaders = F
+    )
+)
+
+# with asHTML as TRUE
+df$link[1] <- paste0(
+    "<a href=",
+    "'https://www.rhs.org.uk/Plants/9355/Iris-setosa/Details'",
+    ">Read more at the RHS</a>"
+)
+datatable(
+    data = df,
+    caption = "Iris Dataset",
+    options = list(
+        responsive = F,
+        rowHeaders = F,
+        asHTML = T
+    )
+)
+
+# with all args + asHTML as false
+datatable(
+    data = df,
+    id = "iris-table",
+    caption = "Iris Dataset",
+    options = list(
+        responsive = TRUE,
+        rowHeaders = TRUE,
+        asHTML = FALSE
+    )
+)


### PR DESCRIPTION
This request includes the following changes to the datatable function.

1. Added new option for rendering cells as html elements rather than strings (see this [post](https://community.rstudio.com/t/how-to-get-a-n-newline-in-table-header-in-blogdown-generated-html/48685/8)). This can be defined through the `asHTML` found in the options argument. Both helper functions were updated.
2. Better handling of options in `build_body` function: cells are built in a few steps. First, the cell value is rendered as html or text. Then, it is determined if the cell should be rendered as a row header or a normal cell (`rowHeader = TRUE` and `col == 1`). Lastly, if the option `responsive = T` is declared, then a `<span>` element is added to the cell generated in step 2. The cells are added to rows and then the body. 
3. The `tbl` object in the main function was updated to render the body and header by default; rather than defining more variables. If I a caption is defined, then it is added using `*$children`. This is much simpler and removes excess code.

This request also includes a testing script for debugging or for understanding how the function works. See `datatable_tests.R` for examples.

Other updates include general revisions to code after switching to a new linting extension in vscode and post-installing radian.