### PR TITLE
*archived* select input app 🗄 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ My interests are in web accessibility, data visualization and communication of r
 | responsive datatables | creating datatables that look good on all screens | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/responsive-tables/)
 | rmarkdown app | Write content in an RMD file and use it as the UI | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/rmarkdown-shiny/)
 | sass in shiny | setting up sass for use in shiny apps | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/sass-in-shiny/)
-| select input styling | custom styling for inputs | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/select-input-styling/)
 | setting html attributes | define and set values for the `<html>` element | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/setting-html-attributes/)
 | shiny landing page | create cool landing pages in shiny | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/landing-page/)
 | shiny links | create links to other tabs | working | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/shiny-link/)
@@ -34,20 +33,23 @@ My interests are in web accessibility, data visualization and communication of r
 
 ### Archived Examples
 
-The examples listed in the following table are achived. They still work, but they are either outdated or were replaced by a newer example.
+The examples listed in the following table are achived. They still work, but they are either outdated or were replaced by a newer example. (I'm a bit hesitant to remove these examples in case some follows a link to a page that doesn't exist.)
 
 | Name | Description | Status | Link |
 | :--- | :---------- | :----  | :--- |
 | internal links basic example\* | learn how to create a link from one shiny page to another | archived | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/internal-links-a/)
 | internal links demo\* | navigate to a specific tab on another shiny page | archived | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/internal-links-c/)
 | internal links\* | create a link to another tab from a leaflet map | archived | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/internal-links-b/)
+| select input styling | custom styling for inputs | archived | [tutorial](https://davidruvolo51.github.io/shinytutorials/tutorials/select-input-styling/)
 
 
-\* These examples are outdated. Instead, use the `shinyLink` component described in the [Shiny Link](https://github.com/davidruvolo51/shinyAppTutorials/tree/prod/shiny-links) subdir. (02 August 2020)
+\* These examples are outdated. Instead, use the `shinyLink` component described in the [Shiny Link](https://github.com/davidruvolo51/shinyAppTutorials/tree/prod/shiny-links) subdirectory. (02 August 2020)
 
 ## Resources
 
-Many of the tutorials use CSS and JavaScript, as well as HTML to create specific layouts and custom designs rather than ShinyUI functions (e.g., fluidPage, navbarPage, etc.). These are good skills to have, and they will come in handy when building custom shiny applications. Here are some links that you may find useful.
+Many of the tutorials rely heavily on HTML, CSS and JavaScript to create specific layouts and interactivity. These are good skills to have, and they will come in handy when building custom applications. Throughout the examples, I've tried to keep things simple and provide links to outside sources where applicable. If something isn't clear or you have suggestions for improvement, feel free to open a new issue. 
+
+If you would like to learn more, here are some links that you may find useful.
 
 ### Web Development
 

--- a/select_input_styling/README.md
+++ b/select_input_styling/README.md
@@ -1,15 +1,7 @@
-# Applying CSS Styles to Select Inputs
+# Updates as of 23 October 2020
 
-The purpose of this app is to demonstration how to style the select input widget in shiny apps. This app was created in response to this community rstudio post: [https://community.rstudio.com/t/selectinput-css-customization/12664/](https://community.rstudio.com/t/selectinput-css-customization/12664).
+Since the last update of this demo application, I have created the [Shiny listbox example](https://github.com/davidruvolo51/shinyAppTutorials/tree/prod/shiny-listbox) as a replacement/alternative to this demo. This demo still works, but the methods in this app are outdated and will no longer be maintained.
 
-> Before you begin, I would use caution in using this approach as overriding browser defaults can cause things to break or not function properly. Check site such as caniuse.com for browerser support before implementing into your production app.
+Questions or comments are always welcome. Feel free to open a new issue.
 
-> Also, the `onfocus` and `onblur` and `onchange` should really be added through javascript listeners. Future updates will correct this and a longer post will be available.
-
-You can run this demo by cloning the [github repository](https://github.com/davidruvolo51/shinyAppTutorials) and opening the Rproject file in `select_input_styling` directory. Alternatively, you can run the app through the console using:
-
-```r
-install.packages(shiny)
-shiny::runGithub(repo="shinyAppTutorials", username="davidruvolo51", subdir="select_input_styling")
-```
-
+\- David


### PR DESCRIPTION
The methods discussed in the [select input styling](https://github.com/davidruvolo51/shinyAppTutorials/tree/prod/select_input_styling) example are outdated. The demo still works, but this app was replaced by the [Shiny Listbox example](https://github.com/davidruvolo51/shinyAppTutorials/tree/prod/shiny-listbox).